### PR TITLE
feat(export): Add Markdown Draft Export Feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,9 @@
                 <button class="btn btn-primary" id="exportHtmlBtn">
                     <i class="fas fa-file-code"></i> 导出HTML
                 </button>
+                <button class="btn btn-primary" id="exportMarkdownDraftBtn">
+                    <i class="fas fa-file-alt"></i> 导出Markdown草稿
+                </button>
                 <a href="https://github.com/xiaolinbaba/Madopic" target="_blank" class="github-link" title="查看GitHub源码">
                     <i class="fab fa-github"></i>
                 </a>

--- a/script.js
+++ b/script.js
@@ -911,6 +911,7 @@ function setupExportButtons() {
     const exportPngBtn = document.getElementById('exportPngBtn');
     const exportPdfBtn = document.getElementById('exportPdfBtn');
     const exportHtmlBtn = document.getElementById('exportHtmlBtn');
+    const exportMarkdownDraftBtn = document.getElementById("exportMarkdownDraftBtn");
 
     if (exportPngBtn) {
         exportPngBtn.addEventListener('click', exportToPNG);
@@ -922,6 +923,10 @@ function setupExportButtons() {
 
     if (exportHtmlBtn) {
         exportHtmlBtn.addEventListener('click', exportToHTML);
+    }
+
+    if (exportMarkdownDraftBtn) {
+        exportMarkdownDraftBtn.addEventListener('click', exportToMarkdownDraft);
     }
 }
 
@@ -1891,6 +1896,80 @@ async function exportToHTML() {
         if (exportNode && exportNode.parentNode) {
             exportNode.parentNode.removeChild(exportNode);
         }
+    }
+}
+
+async function exportToMarkdownDraft() {
+    const draftContent = markdownInput.value;
+
+    if (!draftContent || !draftContent.trim()) {
+        showNotification('编辑器内容为空，无法导出', 'warning');
+        return;
+    }
+
+    let fileName;
+    let matchedTitle = null;
+
+    const patterns = [
+        // 一级标题：# 标题
+        {level: 1, regex: /^#\s+(.+)$/gm},
+        // 二级标题：## 标题
+        {level: 2, regex: /^##\s+(.+)$/gm},
+        // 三级标题：### 标题
+        {level: 3, regex: /^###\s+(.+)$/gm},
+        // 四级标题：#### 标题
+        {level: 4, regex: /^####\s+(.+)$/gm}
+    ];
+
+    // 依次匹配标题
+    for (const pattern of patterns) {
+        const match = pattern.regex.exec(draftContent);
+        if (match) {
+            // 直接取捕获组
+            matchedTitle = match[1].trim();
+            break;
+        }
+    }
+
+    // 没有找到，用时间戳
+    if (!matchedTitle) {
+        matchedTitle = `madopic-draft-${getFormattedTimestamp()}`;
+    }
+
+    fileName = matchedTitle
+        // 去除首尾空格
+        .trim()
+        // 移除控制字符
+        .replace(/[\u0000-\u001F\u007F-\u009F]/g, '')
+        // 移除零宽字符和格式控制符
+        .replace(/[\u200B-\u200F\u202A-\u202E\uFEFF]/g, '')
+        // 移除Windows文件名非法字符
+        .replace(/[\\/:*?"<>|]/g, '')
+        // 多个空格合并为一个
+        .replace(/\s+/g, ' ')
+        // 移除开头的点号和空格
+        .replace(/^[.\s]+/, '')
+        // 移除结尾的点号和空格
+        .replace(/[.\s]+$/, '');
+
+    // 使用时间戳作为后备
+    if (!fileName.length) {
+        fileName = `madopic-draft-${getFormattedTimestamp()}`
+    }
+
+    try {
+        const blob = new Blob([draftContent], { type: 'text/markdown;charset=utf-8' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.download = fileName + '.md';
+        a.href = url;
+        a.click();
+
+        URL.revokeObjectURL(url);
+        showNotification('Markdown草稿 导出成功！', 'success');
+    } catch (error) {
+        console.error('Markdown草稿 导出失败:', error);
+        showNotification('Markdown草稿 导出失败，请重试', 'error');
     }
 }
 


### PR DESCRIPTION
# Add Markdown Draft Export Feature

## 📝 Description

This PR adds a new "Export Markdown Draft" button that allows users to download their current Markdown content as a `.md` file, providing a simple way to backup and preserve their work.

## ✨ What's New

- Added "导出Markdown草稿" button in the toolbar (next to other export buttons)
- Implemented `exportToMarkdownDraft()` function with the following features:
  - **Smart filename generation**: Automatically extracts document title from headings (#, ##, ###, ####) 
  - **Unicode support**: Properly handles Chinese characters, emojis, and special symbols
  - **Filename sanitization**: Removes Windows-illegal characters (`\/:*?"<>|`) and control characters
  - **Fallback mechanism**: Uses timestamp-based naming when no heading is found
  - **User feedback**: Shows success/error notifications
  - **Empty content validation**: Prevents exporting empty documents

## 🔧 Technical Details

### Files Modified
- `index.html`: Added export button in toolbar
- `script.js`: 
  - Added event listener in `setupExportButtons()`
  - Implemented `exportToMarkdownDraft()` function with robust filename handling

### Key Implementation Points
1. **Direct content access**: Reads from `markdownInput.value` instead of localStorage for reliability
2. **Intelligent title extraction**: Prioritizes heading levels (H1 → H4) for meaningful filenames
3. **Comprehensive character filtering**:
   - Removes control characters: `\u0000-\u001F\u007F-\u009F`
   - Removes zero-width characters: `\u200B-\u200F\u202A-\u202E\uFEFF`
   - Preserves all normal Unicode (Chinese, Japanese, Korean, emojis, etc.)
4. **Proper cleanup**: Revokes object URLs to prevent memory leaks

## 💡 Why This Feature?

Currently, when editing Markdown content in the web interface, all changes are lost once the browser tab is closed. Although the application has auto-save functionality using `localStorage`, users have no straightforward way to export their drafts as actual `.md` files for:
- Backup purposes
- Continuing work in external editors (VS Code, Typora, etc.)
- Version control integration
- Sharing with others

Previously, I had to rely on a Tampermonkey userscript to manually extract and save the content. This workaround was inconvenient and not accessible to regular users. This native feature eliminates that need entirely.

## 🧪 How to Test

1. Open the application and edit some Markdown content
2. Add a heading (e.g., `# My Document`)
3. Click the "导出Markdown草稿" button in the toolbar
4. Verify that a `.md` file is downloaded with the correct filename
5. Test scenarios:
   - ✅ Content with different heading levels (#, ##, ###)
   - ✅ Content with Chinese characters and emojis
   - ✅ Content without headings (should use timestamp)
   - ✅ Empty content (should show warning)
   - ✅ Special characters in titles (Windows-illegal chars should be removed)


## 🎯 Benefits

- ✅ No more data loss when closing browser tabs
- ✅ Easy backup and version control
- ✅ Seamless workflow with external Markdown editors
- ✅ User-friendly with intelligent filename generation
- ✅ Consistent with existing export features (PNG, PDF, HTML)